### PR TITLE
DEET-1794 fix

### DIFF
--- a/assets/javascripts/discourse/components/event-form.js.es6
+++ b/assets/javascripts/discourse/components/event-form.js.es6
@@ -11,7 +11,7 @@ import {
 
 export default Component.extend({
   classNames: 'event-form',
-  endEnabled: false,
+  endEnabled: true,
   allDay: false,
   showTimezone: false,
   
@@ -23,7 +23,7 @@ export default Component.extend({
   },
   
   eventValid(event) {
-    return !event || !event.end || moment(event.end).isSameOrAfter(event.start);
+    return !event || !event.end || moment(event.end).isAfter(event.start);
   },
 
   @observes('startDate', 'startTime', 'endDate', 'endTime', 'endEnabled', 'allDay', 'timezone', 'rsvpEnabled', 'goingMax', 'usersGoing')

--- a/assets/javascripts/discourse/templates/components/event-form.hbs
+++ b/assets/javascripts/discourse/templates/components/event-form.hbs
@@ -1,11 +1,4 @@
 <div class="event-controls">
-  <div class="control">
-    <input
-      type="checkbox" 
-      checked={{endEnabled}} 
-      onclick={{action "toggleEndEnabled" value="target.checked"}} />
-    <span>{{i18n 'add_event.end_enabled'}}</span>
-  </div>
   
     <div class="control full-width">
       {{combo-box

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -18,7 +18,7 @@ en:
       going: "Guests"
       going_max: "Maximum guests"
       going_max_label: "{{goingMax}} Guests"
-      error: "Event end should be same as or after event start"
+      error: "Event end must be after event start"
     category:
       events_setting_heading: "Events"
       enable_events: "Allow events to be added to topics in this category (overrides site setting)."


### PR DESCRIPTION
Removes `Multi-day event` checkbox and requires users to have an end date. This fixes calendar issues both in the MUG home page and within the plugin itself.