### PR TITLE
Changed the endpoint to retrieve users rsvp from GET to POST

### DIFF
--- a/assets/javascripts/discourse/controllers/event-rsvp.js.es6
+++ b/assets/javascripts/discourse/controllers/event-rsvp.js.es6
@@ -26,10 +26,10 @@ export default Controller.extend(ModalFunctionality, {
     ajax('/calendar-events/rsvp/users', {
       data:{
         usernames
-      }
+      },
+      type: "POST"
     }).then((response) => {
       let userList = response.users || [];
-      
       this.setProperties({
         userList,
         loadingList: false

--- a/lib/calendar_events.rb
+++ b/lib/calendar_events.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ::CalendarEvents
   class Engine < ::Rails::Engine
     engine_name 'calendar_events'
@@ -11,7 +12,7 @@ CalendarEvents::Engine.routes.draw do
   post '/rsvp/add' => 'rsvp#add'
   post '/rsvp/remove' => 'rsvp#remove'
   get '/api_keys' => 'api_keys#index'
-  get '/rsvp/users' => 'rsvp#users'
+  post '/rsvp/users' => 'rsvp#users'
 end
 
 class CalendarEvents::List
@@ -51,7 +52,6 @@ class CalendarEvents::Helper
         event_end = event_end.in_time_zone(event_timezone)
       end
     end
-
 
     result = {
       start: event_start,


### PR DESCRIPTION
This is to patch when there are many users from an event, the requesting URL can be too long in GET as it list all users in the params. 
